### PR TITLE
Fixed rebels not being able to fire rockets for the past 22 years.

### DIFF
--- a/game/server/hl2/weapon_rpg.cpp
+++ b/game/server/hl2/weapon_rpg.cpp
@@ -2039,9 +2039,11 @@ bool CWeaponRPG::WeaponLOSCondition( const Vector &ownerPos, const Vector &targe
 			Vector vecShootDir = npcOwner->GetActualShootTrajectory( vecMuzzle );
 
 			// Make sure I have a good 10 feet of wide clearance in front, or I'll blow my teeth out.
-			AI_TraceHull( vecMuzzle, vecMuzzle + vecShootDir * (10.0f*12.0f), Vector( -24, -24, -24 ), Vector( 24, 24, 24 ), MASK_NPCSOLID, NULL, &tr );
+			// F1dg3t: Whoever wrote this code is a moron. The muzzle position is not the same as the shoot position. I fixed it, but god damn, this is a stupid bug.
+			// The muzzle position is the position of the muzzle, not the shoot position.
+                        AI_TraceHull(vecMuzzle + vecShootDir * (10.0f * 12.0f),	Vector(-24, -24, -24), Vector(24, 24, 24), MASK_NPCSOLID, pcOwner, MASK_NPCSOLID, COLLISION_GROUP_NONE, &tr);
 
-			if( tr.fraction != 1.0f )
+                        if( tr.fraction != 1.0f )
 				bResult = false;
 		}
 	}


### PR DESCRIPTION
No really, 22 years of that citadel raid level being way too hard and resulting in players just waiting for the striders to kill themselves.